### PR TITLE
Only show hidden tokens to the GM

### DIFF
--- a/src/InitiativeTracker.tsx
+++ b/src/InitiativeTracker.tsx
@@ -34,10 +34,11 @@ export function InitiativeTracker() {
   const [initiativeItems, setInitiativeItems] = useState<InitiativeItem[]>([]);
 
   useEffect(() => {
-    const handleItemsChange = (items: Item[]) => {
+    const handleItemsChange = async (items: Item[]) => {
       const initiativeItems: InitiativeItem[] = [];
+      const isGm = (await OBR.player.getRole()) === 'GM';
       for (const item of items) {
-        if (isImage(item)) {
+        if (isImage(item) && (item.visible || isGm)) {
           const metadata = item.metadata[getPluginId("metadata")];
           if (isMetadata(metadata)) {
             initiativeItems.push({


### PR DESCRIPTION
Hi,

Currently hidden tokens still show up in initative, meaning players can know how many hidden enimies there are.  I don't know if this is really "a bug", but it's not intuitive and a couple of people on discord have expressed supprise by this behavour.

This is a really simple patch that makes hidden tokens only show up for the GM.